### PR TITLE
fix: change default page title

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_default_title.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_default_title.html.eex
@@ -1,3 +1,3 @@
 <title>
-  <%= gettext("JCBI Blockchain Explorer", subnetwork: subnetwork_title()) %>
+  <%= gettext("Content Ethereum Explorer", subnetwork: subnetwork_title()) %>
 </title>


### PR DESCRIPTION
## Motivation
Change default page title.

## Changelog

### Enhancements

### Bug Fixes
Fix page title to `Content Ethereum Explorer`

after change
<img width="694" alt="スクリーンショット 2022-01-21 15 17 06" src="https://user-images.githubusercontent.com/39111286/150477707-acad8108-4884-4b8d-a17a-275e59c387c8.png">


### Incompatible Changes

## Upgrading

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
